### PR TITLE
Implement CPAN RT 120590 - return reasmbs in order

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module Chatbot::Eliza
 
+1.07 2017-04-08 GRANTG
+    - Implemented RT https://rt.cpan.org/Ticket/Display.html?id=120590 to
+      return reasmbs in order
+
 1.06 2015-10-29 NEILB
     - Updated github repo URL after changing my github username
     - Include a META.json in releases, and tag & push to github on release

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = Perl_5
 copyright_holder = John Nolan
 copyright_year   = 2003
 
-version = 1.06
+version = 1.07
 
 [@Basic]
 [PkgVersion]

--- a/lib/Chatbot/Eliza.pm
+++ b/lib/Chatbot/Eliza.pm
@@ -765,10 +765,10 @@ sub transform{
 
 					# Get the list of possible reassembly rules for this key. 
 					#
-                    my $memory = (defined $use_memory and $#{ $self->{reasmblist_for_memory}->{$reasmbkey} } >= 0);
+					my $memory = (defined $use_memory and $#{ $self->{reasmblist_for_memory}->{$reasmbkey} } >= 0);
 
-                    # Pick out next reassembly rule.
-                    $reasmb = $self->_get_next_reasmb( $reasmbkey, $memory);
+					# Pick out next reassembly rule.
+					$reasmb = $self->_get_next_reasmb( $reasmbkey, $memory);
 
 					$self->debug_text($self->debug_text . sprintf "\t\t-->  $reasmb\n");
 
@@ -904,17 +904,17 @@ script data only has 4 such items.
 # next reasmb in the list, wrapping back to the start if the last one
 # is reached.
 sub _get_next_reasmb {
-    my ( $self, $reasmbkey, $memory ) = @_;
+	my ( $self, $reasmbkey, $memory ) = @_;
 
-    my $for_memory = $memory ? '_for_memory' : '';
-    my @these_reasmbs = @{ $self->{"reasmblist$for_memory"}->{$reasmbkey} };
-    my $next_reasmb = $self->{"next_reasmblist$for_memory"}->{$reasmbkey}++;
-    if ( $next_reasmb > scalar( @these_reasmbs ) ) {
-        $next_reasmb = 1;
-        $self->{"next_reasmblist$for_memory"}->{$reasmbkey} = 0;
-    }
+	my $for_memory = $memory ? '_for_memory' : '';
+	my @these_reasmbs = @{ $self->{"reasmblist$for_memory"}->{$reasmbkey} };
+	my $next_reasmb = $self->{"next_reasmblist$for_memory"}->{$reasmbkey}++;
+	if ( $next_reasmb > scalar( @these_reasmbs ) ) {
+		$next_reasmb = 1;
+		$self->{"next_reasmblist$for_memory"}->{$reasmbkey} = 0;
+	}
 
-    return $these_reasmbs[$next_reasmb - 1];
+	return $these_reasmbs[$next_reasmb - 1];
 }
 
 ####################################################################


### PR DESCRIPTION
Hey Neil,

Added my patch to return reasmbs in order instead of randomly - this makes sequential responses (e.g. "I've already told you no apologies are necessary") work as in the original program.

I'm a maintainer on CPAN, so I can release this version if you're bored of maintaining it (talked to John before I figured out you'd taken over and set up a github repo) - but I won't unless you say so, so that we can keep your repo as the master.